### PR TITLE
Restore radar plot and align header controls

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,11 @@
 import { Typography, Box, useTheme } from "@mui/material";
 import { tokens } from "../theme";
 
-const Header = ({ title, subtitle }) => {
+const Header = ({ title, subtitle, mb = "30px" }) => {
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
   return (
-    <Box mb="30px">
+    <Box mb={mb}>
       <Typography
         variant="h2"
         color={colors.grey[100]}

--- a/src/radarplot/RadarSection.jsx
+++ b/src/radarplot/RadarSection.jsx
@@ -5,12 +5,23 @@ const RadarContext = createContext(null);
 
 const round1 = (n) => Math.round(n * 10) / 10;
 
+// Set up default visibility so that all strategies are shown initially
+const INITIAL_VISIBLE = Object.values(DEFAULT_STRATEGIES).reduce(
+  (acc, stratList) => {
+    stratList.forEach((s) => {
+      acc[s.name] = true;
+    });
+    return acc;
+  },
+  {}
+);
+
 export const RadarProvider = ({ children }) => {
   const [selectedCultivations, setSelectedCultivations] = useState(
     Object.keys(DEFAULT_STRATEGIES)
   );
   const [strategies, setStrategies] = useState([]);
-  const [visible, setVisible] = useState({});
+  const [visible, setVisible] = useState(INITIAL_VISIBLE);
 
   useEffect(() => {
     const strategyNames = new Set();
@@ -58,15 +69,6 @@ export const RadarProvider = ({ children }) => {
     setStrategies(averaged);
   }, [selectedCultivations]);
 
-  useEffect(() => {
-    setVisible((prev) => {
-      const vis = { ...prev };
-      strategies.forEach((st) => {
-        if (vis[st.name] === undefined) vis[st.name] = true;
-      });
-      return vis;
-    });
-  }, [strategies]);
 
   const colorMap = useMemo(() => {
     const palette = [
@@ -181,7 +183,7 @@ const RadarControls = () => {
       })}
       {strategies.map((s) => {
         const color = colorMap[s.name];
-        const isOn = visible[s.name];
+        const isOn = visible[s.name] !== false;
         return (
           <button
             key={s.name}

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -20,7 +20,10 @@ const Dashboard = () => {
 
   const RadarChartWrapper = () => {
     const { chartData, strategies, visible, colorMap } = useRadar();
-    const visibleStrategies = strategies.filter((s) => visible[s.name]);
+    // Treat undefined visibility as true so strategies show by default
+    const visibleStrategies = strategies.filter(
+      (s) => visible[s.name] !== false
+    );
     return (
       <RadarPlot
         chartData={chartData}
@@ -41,7 +44,11 @@ const Dashboard = () => {
           className="flex flex-wrap gap-4"
         >
           <div className="flex items-center flex-wrap gap-4">
-            <Header title="DASHBOARD" subtitle="Welcome to your dashboard" />
+            <Header
+              title="DASHBOARD"
+              subtitle="Welcome to your dashboard"
+              mb="0"
+            />
             <RadarControls />
           </div>
 


### PR DESCRIPTION
## Summary
- ensure radar plot renders by default
- move radar controls next to dashboard title
- allow Header component to accept custom margins

## Testing
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6891fcd23f788327b32d844ee5f87b50