### PR TITLE
refactor: move radar controls to header

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -1,0 +1,176 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { DEFAULT_STRATEGIES } from "./defaultStrategies";
+
+const COLOR_PALETTE = [
+  "#FFD700",
+  "#2ca02c",
+  "#d62728",
+  "#1f77b4",
+  "#ff7f0e",
+  "#9467bd",
+  "#8c564b",
+  "#e377c2",
+  "#7f7f7f",
+  "#17becf",
+];
+
+const RadarContext = createContext();
+
+export const useRadar = () => useContext(RadarContext);
+
+export const RadarProvider = ({ data, children }) => {
+  const baseData = data && Object.keys(data).length ? data : DEFAULT_STRATEGIES;
+  const cultivationKeys = Object.keys(baseData);
+  const defaultCultivations = cultivationKeys.slice(0, 2);
+  const [selectedCultivations, setSelectedCultivations] = useState(defaultCultivations);
+  const [strategies, setStrategies] = useState([]);
+  const [visible, setVisible] = useState({});
+
+  useEffect(() => {
+    const strategyNames = new Set();
+    selectedCultivations.forEach((c) => {
+      (baseData[c] || []).forEach((s) => strategyNames.add(s.name));
+    });
+    const averaged = Array.from(strategyNames).map((name) => {
+      let count = 0;
+      let bonus_penalty = 0;
+      let profit = 0;
+      let energy_cost = 0;
+      let weight_achieved = 0;
+      let base_revenue_a = 0;
+      let base_revenue_b = 0;
+      let base_revenue = 0;
+      selectedCultivations.forEach((c) => {
+        const st = (baseData[c] || []).find((s) => s.name === name);
+        if (st) {
+          bonus_penalty += Number(st.bonus_penalty) || 0;
+          profit += Number(st.profit) || 0;
+          energy_cost += Number(st.energy_cost) || 0;
+          weight_achieved += Number(st.weight_achieved) || 0;
+          base_revenue_a += Number(st.base_revenue_a) || 0;
+          base_revenue_b += Number(st.base_revenue_b) || 0;
+          base_revenue +=
+            st.base_revenue !== undefined
+              ? Number(st.base_revenue) || 0
+              : (Number(st.base_revenue_a) || 0) + (Number(st.base_revenue_b) || 0);
+          count += 1;
+        }
+      });
+      const denom = count || 1;
+      return {
+        name,
+        bonus_penalty: Math.round((bonus_penalty / denom) * 10) / 10,
+        profit: Math.round((profit / denom) * 10) / 10,
+        energy_cost: Math.round((energy_cost / denom) * 10) / 10,
+        weight_achieved: Math.round((weight_achieved / denom) * 10) / 10,
+        base_revenue_a: Math.round((base_revenue_a / denom) * 10) / 10,
+        base_revenue_b: Math.round((base_revenue_b / denom) * 10) / 10,
+        base_revenue: Math.round((base_revenue / denom) * 10) / 10,
+      };
+    });
+    setStrategies(averaged);
+  }, [selectedCultivations, baseData]);
+
+  useEffect(() => {
+    setVisible((prev) => {
+      const vis = { ...prev };
+      strategies.forEach((st) => {
+        if (vis[st.name] === undefined) vis[st.name] = true;
+      });
+      return vis;
+    });
+  }, [strategies]);
+
+  const colorMap = useMemo(() => {
+    const sorted = [...strategies].sort(
+      (a, b) => (Number(b.profit) || 0) - (Number(a.profit) || 0)
+    );
+    const map = {};
+    sorted.forEach((s, idx) => {
+      map[s.name] = COLOR_PALETTE[idx % COLOR_PALETTE.length];
+    });
+    return map;
+  }, [strategies]);
+
+  const toggleCultivation = (name) => {
+    setSelectedCultivations((prev) =>
+      prev.includes(name) ? prev.filter((c) => c !== name) : [...prev, name]
+    );
+  };
+
+  const toggleStrategy = (name) => {
+    setVisible((v) => ({ ...v, [name]: !v[name] }));
+  };
+
+  const value = {
+    strategies,
+    visible,
+    colorMap,
+    selectedCultivations,
+    toggleStrategy,
+    toggleCultivation,
+    allCultivations: cultivationKeys,
+  };
+
+  return <RadarContext.Provider value={value}>{children}</RadarContext.Provider>;
+};
+
+const RadarControls = () => {
+  const {
+    allCultivations,
+    selectedCultivations,
+    strategies,
+    visible,
+    colorMap,
+    toggleStrategy,
+    toggleCultivation,
+  } = useRadar();
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex justify-center gap-2 flex-wrap">
+        {allCultivations.map((c) => {
+          const isSelected = selectedCultivations.includes(c);
+          return (
+            <button
+              key={c}
+              type="button"
+              onClick={() => toggleCultivation(c)}
+              className={`px-3 py-1 rounded-full text-sm font-semibold border ${
+                isSelected
+                  ? "bg-blue-500 text-white border-blue-500"
+                  : "text-blue-500 border-blue-500"
+              }`}
+            >
+              {c}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-6 flex justify-center gap-2 flex-wrap">
+        {strategies.map((s) => {
+          const color = colorMap[s.name];
+          const isOn = visible[s.name];
+          return (
+            <button
+              key={s.name}
+              type="button"
+              onClick={() => toggleStrategy(s.name)}
+              className="px-3 py-1 rounded-full text-sm font-semibold border"
+              style={{
+                borderColor: color,
+                backgroundColor: isOn ? color : "transparent",
+                color: isOn ? "#000" : color,
+              }}
+            >
+              {s.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default RadarControls;
+

--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Radar,
   RadarChart,
@@ -6,21 +6,6 @@ import {
   PolarAngleAxis,
   PolarRadiusAxis,
 } from "recharts";
-
-import { DEFAULT_STRATEGIES } from "./defaultStrategies";
-
-const COLOR_PALETTE = [
-  "#FFD700",
-  "#2ca02c",
-  "#d62728",
-  "#1f77b4",
-  "#ff7f0e",
-  "#9467bd",
-  "#8c564b",
-  "#e377c2",
-  "#7f7f7f",
-  "#17becf",
-];
 
 const round1 = (n) => Math.round(n * 10) / 10;
 
@@ -86,80 +71,14 @@ const renderAngleTick = (props) => {
   );
 };
 
-const RadarPlot = () => {
-  const [selectedCultivations, setSelectedCultivations] = useState(
-    Object.keys(DEFAULT_STRATEGIES)
-  );
-  const [strategies, setStrategies] = useState([]);
-  const [visible, setVisible] = useState({});
-
-  useEffect(() => {
-    const strategyNames = new Set();
-    selectedCultivations.forEach((c) => {
-      DEFAULT_STRATEGIES[c].forEach((s) => strategyNames.add(s.name));
-    });
-    const averaged = Array.from(strategyNames).map((name) => {
-      let count = 0;
-      let bonus_penalty = 0;
-      let profit = 0;
-      let energy_cost = 0;
-      let weight_achieved = 0;
-      let base_revenue_a = 0;
-      let base_revenue_b = 0;
-      let base_revenue = 0;
-      selectedCultivations.forEach((c) => {
-        const st = DEFAULT_STRATEGIES[c].find((s) => s.name === name);
-        if (st) {
-          bonus_penalty += Number(st.bonus_penalty) || 0;
-          profit += Number(st.profit) || 0;
-          energy_cost += Number(st.energy_cost) || 0;
-          weight_achieved += Number(st.weight_achieved) || 0;
-          base_revenue_a += Number(st.base_revenue_a) || 0;
-          base_revenue_b += Number(st.base_revenue_b) || 0;
-          base_revenue +=
-            st.base_revenue !== undefined
-              ? Number(st.base_revenue) || 0
-              : (Number(st.base_revenue_a) || 0) +
-                (Number(st.base_revenue_b) || 0);
-          count += 1;
-        }
-      });
-      const denom = count || 1;
-      return {
-        name,
-        bonus_penalty: round1(bonus_penalty / denom),
-        profit: round1(profit / denom),
-        energy_cost: round1(energy_cost / denom),
-        weight_achieved: round1(weight_achieved / denom),
-        base_revenue_a: round1(base_revenue_a / denom),
-        base_revenue_b: round1(base_revenue_b / denom),
-        base_revenue: round1(base_revenue / denom),
-      };
-    });
-    setStrategies(averaged);
-  }, [selectedCultivations]);
-
-  useEffect(() => {
-    setVisible((prev) => {
-      const vis = { ...prev };
-      strategies.forEach((st) => {
-        if (vis[st.name] === undefined) vis[st.name] = true;
-      });
-      return vis;
-    });
-  }, [strategies]);
-
-  const colorMap = useMemo(() => {
-    const sorted = [...strategies].sort(
-      (a, b) => (Number(b.profit) || 0) - (Number(a.profit) || 0)
-    );
-    const map = {};
-    sorted.forEach((s, idx) => {
-      map[s.name] = COLOR_PALETTE[idx % COLOR_PALETTE.length];
-    });
-    return map;
-  }, [strategies]);
-
+const RadarPlot = ({
+  strategies = [],
+  visible = {},
+  colorMap = {},
+  selectedCultivations, // unused but accepted via props
+  toggleStrategy, // unused but accepted via props
+  toggleCultivation, // unused but accepted via props
+}) => {
   const chartData = useMemo(() => {
     return KPI_FIELDS.map((kpi) => {
       const [domainMin, domainMax] = KPI_RANGES[kpi.key];
@@ -174,58 +93,8 @@ const RadarPlot = () => {
     });
   }, [strategies]);
 
-  const toggleCultivation = (name) => {
-    setSelectedCultivations((prev) =>
-      prev.includes(name) ? prev.filter((c) => c !== name) : [...prev, name]
-    );
-  };
-
-  const toggle = (name) => {
-    setVisible((v) => ({ ...v, [name]: !v[name] }));
-  };
-
   return (
     <div style={{ width: "100%", height: "100%" }}>
-      <div className="flex justify-center gap-2 flex-wrap">
-        {Object.keys(DEFAULT_STRATEGIES).map((c) => {
-          const isSelected = selectedCultivations.includes(c);
-          return (
-            <button
-              key={c}
-              type="button"
-              onClick={() => toggleCultivation(c)}
-              className={`px-3 py-1 rounded-full text-sm font-semibold border ${
-                isSelected
-                  ? "bg-blue-500 text-white border-blue-500"
-                  : "text-blue-500 border-blue-500"
-              }`}
-            >
-              {c}
-            </button>
-          );
-        })}
-      </div>
-      <div className="mt-6 flex justify-center gap-2 flex-wrap">
-        {strategies.map((s) => {
-          const color = colorMap[s.name];
-          const isOn = visible[s.name];
-          return (
-            <button
-              key={s.name}
-              type="button"
-              onClick={() => toggle(s.name)}
-              className="px-3 py-1 rounded-full text-sm font-semibold border"
-              style={{
-                borderColor: color,
-                backgroundColor: isOn ? color : "transparent",
-                color: isOn ? "#000" : color,
-              }}
-            >
-              {s.name}
-            </button>
-          );
-        })}
-      </div>
       <div className="mt-8 flex justify-center">
         <RadarChart
           cx="50%"

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -12,16 +12,21 @@ import GeographyChart from "../../components/GeographyChart";
 import BarChart from "../../components/BarChart";
 import StatBox from "../../components/StatBox";
 import RadarPlot from "../../radarplot/RadarPlot";
+import RadarControls, { RadarProvider, useRadar } from "../../radarplot/RadarControls";
 
-const Dashboard = () => {
+const DashboardContent = () => {
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
+  const radar = useRadar();
 
   return (
     <Box m="20px">
       {/* HEADER */}
       <Box display="flex" justifyContent="space-between" alignItems="center">
-        <Header title="DASHBOARD" subtitle="Welcome to your dashboard" />
+        <Box display="flex" alignItems="center" gap="20px">
+          <Header title="DASHBOARD" subtitle="Welcome to your dashboard" />
+          <RadarControls />
+        </Box>
 
         <Box>
           <Button
@@ -224,7 +229,7 @@ const Dashboard = () => {
           p="30px"
         >
           <Box height="300px">
-            <RadarPlot />
+            <RadarPlot {...radar} />
           </Box>
         </Box>
         <Box
@@ -264,5 +269,11 @@ const Dashboard = () => {
     </Box>
   );
 };
+
+const Dashboard = () => (
+  <RadarProvider>
+    <DashboardContent />
+  </RadarProvider>
+);
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- move cultivation and strategy toggles into new `RadarControls` component with shared state
- render `RadarControls` next to dashboard header and pass its props to `RadarPlot`
- convert `RadarPlot` into presentational chart driven by props

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: unable to resolve dependency tree)*


------
https://chatgpt.com/codex/tasks/task_e_68920949788c8327b57b7b7c6961fac4