### PR TITLE
Make radar chart responsive

### DIFF
--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -5,6 +5,7 @@ import {
   PolarGrid,
   PolarAngleAxis,
   PolarRadiusAxis,
+  ResponsiveContainer,
 } from "recharts";
 
 const round1 = (n) => Math.round(n * 10) / 10;
@@ -94,14 +95,12 @@ const RadarPlot = ({
   }, [strategies]);
 
   return (
-    <div style={{ width: "100%", height: "100%" }}>
-      <div className="mt-8 flex justify-center">
+    <div className="w-full h-full flex items-center justify-center">
+      <ResponsiveContainer width="100%" height="100%">
         <RadarChart
           cx="50%"
           cy="50%"
           outerRadius="80%"
-          width={250}
-          height={200}
           data={chartData}
           margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
         >
@@ -131,7 +130,7 @@ const RadarPlot = ({
               );
             })}
         </RadarChart>
-      </div>
+      </ResponsiveContainer>
     </div>
   );
 };

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -241,11 +241,9 @@ const DashboardContent = () => {
           gridColumn="9 / span 4"
           gridRow="span 2"
           backgroundColor={colors.primary[400]}
-          p="30px"
+          className="w-full h-full p-4"
         >
-          <Box height="300px">
-            <RadarPlot {...radar} />
-          </Box>
+          <RadarPlot {...radar} />
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- Replace fixed-size RadarChart with ResponsiveContainer
- Expand RadarPlot dashboard container to use full widget space

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68925f451ae48327a30874458743ba00