### PR TITLE
Load dashboard metrics from gist

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -26,6 +26,12 @@ export const RadarProvider = ({ data, children }) => {
   const [strategies, setStrategies] = useState([]);
   const [visible, setVisible] = useState({});
 
+  // Reset selections when incoming data changes
+  useEffect(() => {
+    setSelectedCultivations(defaultCultivations);
+    setVisible({});
+  }, [data]);
+
   useEffect(() => {
     const strategyNames = new Set();
     selectedCultivations.forEach((c) => {

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -1,4 +1,5 @@
 import { Box, Button, IconButton, Typography, useTheme } from "@mui/material";
+import { useEffect, useState } from "react";
 import { tokens } from "../../theme";
 import { mockTransactions } from "../../data/mockData";
 import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
@@ -250,10 +251,41 @@ const DashboardContent = () => {
   );
 };
 
-const Dashboard = () => (
-  <RadarProvider>
-    <DashboardContent />
-  </RadarProvider>
-);
+const Dashboard = () => {
+  const [gistData, setGistData] = useState(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const gistId = params.get("gist");
+    if (!gistId) return;
+
+    const fetchData = async () => {
+      try {
+        const res = await fetch(`https://api.github.com/gists/${gistId}`);
+        const json = await res.json();
+        const files = json.files || {};
+        const firstFile = Object.values(files)[0];
+        if (firstFile && firstFile.content) {
+          try {
+            const parsed = JSON.parse(firstFile.content);
+            setGistData(parsed);
+          } catch (err) {
+            console.error("Failed to parse gist JSON", err);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch gist", err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <RadarProvider data={gistData}>
+      <DashboardContent />
+    </RadarProvider>
+  );
+};
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- allow passing `gist` query parameter to load radar data from a GitHub Gist
- reset cultivation/strategy selections when new gist data arrives

## Testing
- `CI=true npm test -- --passWithNoTests --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6892665d6b2c832787ed530ca5f1dde8