### PR TITLE
feat: support data_url param for dashboard

### DIFF
--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -258,6 +258,7 @@ const Dashboard = () => {
     const params = new URLSearchParams(window.location.search);
     const gistId = params.get("gist");
     const dataParam = params.get("data");
+    const dataUrl = params.get("data_url");
 
     if (dataParam) {
       try {
@@ -266,6 +267,21 @@ const Dashboard = () => {
       } catch (err) {
         console.error("Failed to parse data param", err);
       }
+      return;
+    }
+
+    if (dataUrl) {
+      const fetchDataUrl = async () => {
+        try {
+          const res = await fetch(dataUrl);
+          const json = await res.json();
+          setGistData(json);
+        } catch (err) {
+          console.error("Failed to fetch data_url JSON", err);
+        }
+      };
+
+      fetchDataUrl();
       return;
     }
 


### PR DESCRIPTION
## Summary
- allow dashboard to load data from raw URL via `data_url` query parameter
- retain existing `gist` and inline `data` param behavior

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892fd0af604832793e27cbcfbd37570