### PR TITLE
feat: expose batches from query

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -35,7 +35,7 @@ const buildData = (raw = DEFAULT_STRATEGIES) => {
   };
 };
 
-export const RadarProvider = ({ data = {}, children }) => {
+export const RadarProvider = ({ data = {}, batches = [], children }) => {
   const baseData = useMemo(() => {
     if (data) {
       if (data.cultivations) return data;
@@ -143,6 +143,7 @@ export const RadarProvider = ({ data = {}, children }) => {
     toggleStrategy,
     toggleCultivation,
     allCultivations,
+    batches,
   };
 
   return <RadarContext.Provider value={value}>{children}</RadarContext.Provider>;

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -253,12 +253,22 @@ const DashboardContent = () => {
 
 const Dashboard = () => {
   const [gistData, setGistData] = useState(null);
+  const [batches, setBatches] = useState([]);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const gistId = params.get("gist");
     const dataParam = params.get("data");
     const dataUrl = params.get("data_url");
+    const batchesParam = params.get("batches");
+
+    if (batchesParam) {
+      const parsedBatches = batchesParam
+        .split(",")
+        .map((b) => b.trim())
+        .filter(Boolean);
+      setBatches(parsedBatches);
+    }
 
     if (dataParam) {
       try {
@@ -310,7 +320,7 @@ const Dashboard = () => {
   }, []);
 
   return (
-    <RadarProvider data={gistData}>
+    <RadarProvider data={gistData} batches={batches}>
       <DashboardContent />
     </RadarProvider>
   );


### PR DESCRIPTION
## Summary
- parse comma-separated batches from dashboard URL
- provide parsed batches via Radar context for downstream filtering

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689302e2ce908327a0be20bd02da7f6e