### PR TITLE
feat: compute kpi averages for stat cards

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -144,6 +144,7 @@ export const RadarProvider = ({ data = {}, batches = [], children }) => {
     toggleCultivation,
     allCultivations,
     batches,
+    kpis: baseData.kpis,
   };
 
   return <RadarContext.Provider value={value}>{children}</RadarContext.Provider>;


### PR DESCRIPTION
## Summary
- expose KPI data from RadarProvider context
- compute average KPI stats for selected cultivations and visible strategies
- display energy, plant, cost and profit efficiency in dashboard stat cards

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689312a89d0083279e9ab33977eaf43a