### PR TITLE
Stack strategy labels and average per cultivation

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -184,7 +184,7 @@ const RadarControls = () => {
       </div>
 
       {/* Strategy buttons */}
-      <div className="flex flex-wrap gap-3">
+      <div className="flex flex-col gap-3">
         {strategies.map((s) => {
           const isVisible = visible[s.name];
           const color = colorMap[s.name] || "#999";

--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -10,16 +10,20 @@ import {
 
 const round1 = (n) => Math.round(n * 10) / 10;
 
-function renderActiveDot(color, name) {
+function renderActiveDot(color, name, idx) {
   return (props) => {
     const { cx, cy, payload } = props;
     const raw = round1(payload[`${name}-raw`]);
+    // Offset labels vertically so multiple strategies don't overlap
+    const direction = idx % 2 === 0 ? -1 : 1;
+    const step = Math.ceil((idx + 1) / 2);
+    const offset = direction * step * 12; // 12px per step
     return (
       <g>
         <circle cx={cx} cy={cy} r={4} stroke={color} strokeWidth={2} fill="#fff" />
         <text
           x={cx}
-          y={Number(cy) - 8}
+          y={Number(cy) + offset}
           textAnchor="middle"
           fill={color}
           fontSize={12}
@@ -114,7 +118,7 @@ const RadarPlot = ({
           />
           {strategies
             .filter((s) => visible[s.name])
-            .map((s) => {
+            .map((s, idx) => {
               const color = colorMap[s.name];
               return (
                 <Radar
@@ -125,7 +129,7 @@ const RadarPlot = ({
                   fill={color}
                   fillOpacity={0.4}
                   dot={{ r: 3, stroke: color, fill: color }}
-                  activeDot={renderActiveDot(color, s.name)}
+                  activeDot={renderActiveDot(color, s.name, idx)}
                 />
               );
             })}

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -57,18 +57,33 @@ const DashboardContent = () => {
     const strategies = Object.keys(visible || {}).filter((s) => visible[s]);
 
     selectedCultivations.forEach((cultivation) => {
+      const stratTotals = {
+        euro_per_kwh: 0,
+        kwh_per_gram: 0,
+        euro_per_gram: 0,
+        profit_per_m2: 0,
+      };
+      let stratCount = 0;
+
       strategies.forEach((strategy) => {
         const data = kpis ? kpis[`${cultivation}|${strategy}`] : undefined;
         if (data) {
-          Object.keys(totals).forEach((key) => {
+          Object.keys(stratTotals).forEach((key) => {
             const val = Number(data[key]);
             if (!isNaN(val)) {
-              totals[key] += val;
-              counts[key] += 1;
+              stratTotals[key] += val;
             }
           });
+          stratCount += 1;
         }
       });
+
+      if (stratCount > 0) {
+        Object.keys(totals).forEach((key) => {
+          totals[key] += stratTotals[key] / stratCount;
+          counts[key] += 1;
+        });
+      }
     });
 
     const averages = {};


### PR DESCRIPTION
## Summary
- Offset radar labels so strategy values stack vertically and use strategy colors
- List strategy controls vertically
- Average dashboard KPIs across cultivations instead of strategy-cultivation pairs

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68931c36f7908327acbc7e379924c3aa