### PR TITLE
Revert vertical strategy layout and show per-strategy KPI stats

### DIFF
--- a/src/components/StatBox.jsx
+++ b/src/components/StatBox.jsx
@@ -2,7 +2,7 @@ import { Box, Typography, useTheme } from "@mui/material";
 import { tokens } from "../theme";
 import ProgressCircle from "./ProgressCircle";
 
-const StatBox = ({ title, subtitle, icon, progress, increase }) => {
+const StatBox = ({ title, lines, subtitle, icon, progress, increase }) => {
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
 
@@ -11,29 +11,46 @@ const StatBox = ({ title, subtitle, icon, progress, increase }) => {
       <Box display="flex" justifyContent="space-between">
         <Box>
           {icon}
-          <Typography
-            variant="h4"
-            fontWeight="bold"
-            sx={{ color: colors.grey[100] }}
-          >
-            {title}
-          </Typography>
+          {lines
+            ? lines.map((line, idx) => (
+                <Typography
+                  key={idx}
+                  variant="h4"
+                  fontWeight="bold"
+                  sx={{ color: line.color }}
+                >
+                  {line.label}
+                </Typography>
+              ))
+            : (
+                <Typography
+                  variant="h4"
+                  fontWeight="bold"
+                  sx={{ color: colors.grey[100] }}
+                >
+                  {title}
+                </Typography>
+              )}
         </Box>
-        <Box>
-          <ProgressCircle progress={progress} />
-        </Box>
+        {progress !== undefined && (
+          <Box>
+            <ProgressCircle progress={progress} />
+          </Box>
+        )}
       </Box>
       <Box display="flex" justifyContent="space-between" mt="2px">
         <Typography variant="h5" sx={{ color: colors.greenAccent[500] }}>
           {subtitle}
         </Typography>
-        <Typography
-          variant="h5"
-          fontStyle="italic"
-          sx={{ color: colors.greenAccent[600] }}
-        >
-          {increase}
-        </Typography>
+        {increase && (
+          <Typography
+            variant="h5"
+            fontStyle="italic"
+            sx={{ color: colors.greenAccent[600] }}
+          >
+            {increase}
+          </Typography>
+        )}
       </Box>
     </Box>
   );

--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -184,7 +184,7 @@ const RadarControls = () => {
       </div>
 
       {/* Strategy buttons */}
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-3">
         {strategies.map((s) => {
           const isVisible = visible[s.name];
           const color = colorMap[s.name] || "#999";

--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -10,20 +10,16 @@ import {
 
 const round1 = (n) => Math.round(n * 10) / 10;
 
-function renderActiveDot(color, name, idx) {
+function renderActiveDot(color, name) {
   return (props) => {
     const { cx, cy, payload } = props;
     const raw = round1(payload[`${name}-raw`]);
-    // Offset labels vertically so multiple strategies don't overlap
-    const direction = idx % 2 === 0 ? -1 : 1;
-    const step = Math.ceil((idx + 1) / 2);
-    const offset = direction * step * 12; // 12px per step
     return (
       <g>
         <circle cx={cx} cy={cy} r={4} stroke={color} strokeWidth={2} fill="#fff" />
         <text
           x={cx}
-          y={Number(cy) + offset}
+          y={Number(cy) - 8}
           textAnchor="middle"
           fill={color}
           fontSize={12}
@@ -118,7 +114,7 @@ const RadarPlot = ({
           />
           {strategies
             .filter((s) => visible[s.name])
-            .map((s, idx) => {
+            .map((s) => {
               const color = colorMap[s.name];
               return (
                 <Radar
@@ -129,7 +125,7 @@ const RadarPlot = ({
                   fill={color}
                   fillOpacity={0.4}
                   dot={{ r: 3, stroke: color, fill: color }}
-                  activeDot={renderActiveDot(color, s.name, idx)}
+                  activeDot={renderActiveDot(color, s.name)}
                 />
               );
             })}


### PR DESCRIPTION
## Summary
- Revert "display strategies vertically" merge to restore horizontal strategy buttons and original radar labels
- Show each strategy's KPI value inside the dashboard stat boxes, colored to match strategy buttons
- Expand `StatBox` to accept multi-line, color-coded entries

## Testing
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6893203cccb48327a1410b81b7337fa4