### PR TITLE
Fix weight display in radar plot

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -79,7 +79,8 @@ export const RadarProvider = ({ data = {}, batches = [], children }) => {
           bonus_penalty += Number(st.bonus_penalty) || 0;
           profit += Number(st.profit) || 0;
           energy_cost += Number(st.energy_cost) || 0;
-          weight_achieved += Number(st.weight_achieved) || 0;
+          const weightVal = st.weight_achieved ?? st.weight ?? st.total_weight;
+          weight_achieved += Number(weightVal) || 0;
           base_revenue_a += Number(st.base_revenue_a) || 0;
           base_revenue_b += Number(st.base_revenue_b) || 0;
           base_revenue +=

--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -43,7 +43,7 @@ const KPI_FIELDS = [
 const KPI_RANGES = {
   profit: [0, 50],
   energy_cost: [0, 8],
-  weight_achieved: [20, 100],
+  weight_achieved: [0, 100],
   bonus_penalty: [-3, 5],
   base_revenue: [0, 35],
 };


### PR DESCRIPTION
## Summary
- allow weight below 20 in radar plot
- accept alternate weight field names when averaging KPIs

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68932ae66c188327bdd8a90c2a8f2d19