### PR TITLE
Fix radar weight averaging

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -78,8 +78,15 @@ export const RadarProvider = ({ data = {}, batches = [], children }) => {
           bonus_penalty += Number(st.bonus_penalty) || 0;
           profit += Number(st.profit) || 0;
           energy_cost += Number(st.energy_cost) || 0;
-          const weightVal = st.weight_achieved ?? st.weight ?? st.total_weight;
-          weight_achieved += Number(weightVal) || 0;
+          const weightVal =
+            st.weight_achieved ??
+            st.weight ??
+            st.total_weight ??
+            st.harvest_weight_g;
+          const numericWeight = parseFloat(weightVal);
+          if (!Number.isNaN(numericWeight)) {
+            weight_achieved += numericWeight;
+          }
           base_revenue_a += Number(st.base_revenue_a) || 0;
           base_revenue_b += Number(st.base_revenue_b) || 0;
           base_revenue +=


### PR DESCRIPTION
## Summary
- handle `harvest_weight_g` when computing strategy weights for radar chart
- ignore non-numeric weight values instead of coercing to 0

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689334c14d4c8327879d0b5b64873b77