### PR TITLE
Adjust Y-axis lower bound in line chart

### DIFF
--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -7,6 +7,11 @@ const LineChart = ({ isCustomLineColors = false, isDashboard = false }) => {
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
 
+  const yMin = Math.min(
+    ...data.flatMap((series) => series.data.map((d) => d.y))
+  );
+  const lowerBound = yMin < 0 ? yMin : 0;
+
   return (
     <ResponsiveLine
       data={data}
@@ -48,7 +53,7 @@ const LineChart = ({ isCustomLineColors = false, isDashboard = false }) => {
       xScale={{ type: "point" }}
       yScale={{
         type: "linear",
-        min: "auto",
+        min: lowerBound,
         max: "auto",
         stacked: true,
         reverse: false,


### PR DESCRIPTION
## Summary
- ensure line chart Y-axis starts at 0 unless data includes negatives

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6893627bd3608327a4b34806784cac8f