### PR TITLE
Round displayed metrics to three decimals

### DIFF
--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -171,6 +171,7 @@ const BarChart = ({ energyData = {} }) => {
             legend: "€",
             legendPosition: "middle",
             legendOffset: -40,
+            format: (value) => Number(value).toFixed(3),
           }}
           enableLabel={false}
           theme={{
@@ -196,7 +197,7 @@ const BarChart = ({ energyData = {} }) => {
               <Typography variant="body2">{data.date}</Typography>
               {Object.entries(data.values || {}).map(([s, v]) => (
                 <Typography key={s} variant="body2">
-                  {s}: {v}
+                  {s}: {Number(v).toFixed(3)}
                 </Typography>
               ))}
             </Box>

--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -58,7 +58,7 @@ const LineChart = ({ isCustomLineColors = false, isDashboard = false }) => {
         stacked: true,
         reverse: false,
       }}
-      yFormat=" >-.2f"
+      yFormat=" >-.3f"
       curve="catmullRom"
       axisTop={null}
       axisRight={null}
@@ -80,6 +80,7 @@ const LineChart = ({ isCustomLineColors = false, isDashboard = false }) => {
         legend: isDashboard ? undefined : "count", // added
         legendOffset: -40,
         legendPosition: "middle",
+        format: (value) => Number(value).toFixed(3),
       }}
       enableGridX={false}
       enableGridY={false}

--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -99,13 +99,13 @@ export const RadarProvider = ({ data = {}, batches = [], children }) => {
       const denom = count || 1;
       return {
         name,
-        bonus_penalty: Math.round((bonus_penalty / denom) * 10) / 10,
-        profit: Math.round((profit / denom) * 10) / 10,
-        energy_cost: Math.round((energy_cost / denom) * 10) / 10,
-        weight_achieved: Math.round((weight_achieved / denom) * 10) / 10,
-        base_revenue_a: Math.round((base_revenue_a / denom) * 10) / 10,
-        base_revenue_b: Math.round((base_revenue_b / denom) * 10) / 10,
-        base_revenue: Math.round((base_revenue / denom) * 10) / 10,
+        bonus_penalty: Math.round((bonus_penalty / denom) * 1000) / 1000,
+        profit: Math.round((profit / denom) * 1000) / 1000,
+        energy_cost: Math.round((energy_cost / denom) * 1000) / 1000,
+        weight_achieved: Math.round((weight_achieved / denom) * 1000) / 1000,
+        base_revenue_a: Math.round((base_revenue_a / denom) * 1000) / 1000,
+        base_revenue_b: Math.round((base_revenue_b / denom) * 1000) / 1000,
+        base_revenue: Math.round((base_revenue / denom) * 1000) / 1000,
       };
     });
     setStrategies(averaged);

--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -8,12 +8,12 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-const round1 = (n) => Math.round(n * 10) / 10;
+const round3 = (n) => Math.round(n * 1000) / 1000;
 
 function renderActiveDot(color, name) {
   return (props) => {
     const { cx, cy, payload } = props;
-    const raw = round1(payload[`${name}-raw`]);
+    const raw = round3(payload[`${name}-raw`]);
     return (
       <g>
         <circle cx={cx} cy={cy} r={4} stroke={color} strokeWidth={2} fill="#fff" />
@@ -88,7 +88,7 @@ const RadarPlot = ({
         const v = Number(s[kpi.key]) || 0;
         const scaled = (v - domainMin) / (domainMax - domainMin);
         entry[s.name] = scaled;
-        entry[`${s.name}-raw`] = round1(v);
+        entry[`${s.name}-raw`] = round3(v);
       });
       return entry;
     });


### PR DESCRIPTION
## Summary
- Round radar KPI averages to three decimal places
- Format bar and line charts to display values with three-decimal precision
- Show radar plot raw values using three decimal rounding

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68936b68ac88832788f4e59d53566943