### PR TITLE
Fix tooltip values and show total profit

### DIFF
--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -191,21 +191,25 @@ const BarChart = ({ energyData = {} }) => {
               },
             },
           }}
-          tooltip={({ data }) => (
-            <Box p={1}>
-              <Typography variant="body2">{data.date}</Typography>
-              {strategyKeys.map((key) => {
-                const name = data[`strategy_${key}`];
-                if (!name) return null;
-                const val = Number(data[key] || 0);
-                return (
-                  <Typography key={key} variant="body2">
-                    {name}: {val.toFixed(3)}
-                  </Typography>
-                );
-              })}
-            </Box>
-          )}
+          tooltip={({ data }) => {
+            let cumulative = 0;
+            return (
+              <Box p={1}>
+                <Typography variant="body2">{data.date}</Typography>
+                {strategyKeys.map((key) => {
+                  const name = data[`strategy_${key}`];
+                  if (!name) return null;
+                  const val = Number(data[key] || 0);
+                  cumulative += val;
+                  return (
+                    <Typography key={key} variant="body2">
+                      {name}: {cumulative.toFixed(3)}
+                    </Typography>
+                  );
+                })}
+              </Box>
+            );
+          }}
         />
       </Box>
     </Box>

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -86,7 +86,7 @@ const DashboardContent = ({ energyData }) => {
         euro_per_kwh: 0,
         kwh_per_gram: 0,
         euro_per_gram: 0,
-        profit_per_m2: 0,
+        profit: 0,
       };
       let count = 0;
 
@@ -172,8 +172,8 @@ const DashboardContent = ({ energyData }) => {
           justifyContent="center"
         >
           <StatBox
-            lines={buildLines("profit_per_m2")}
-            subtitle="Profit per m² (€/m²)"
+            lines={buildLines("profit")}
+            subtitle="Total Profit (€)"
             icon={
               <EuroSymbolIcon
                 sx={{ color: colors.greenAccent[600], fontSize: "26px" }}


### PR DESCRIPTION
## Summary
- show absolute strategy totals in bar chart tooltip
- display total profit instead of profit per m²

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68937fc7c5f48327af3d4274013a131e