### PR TITLE
Add energy cost per profit metric and profit comparison

### DIFF
--- a/src/components/StatBox.jsx
+++ b/src/components/StatBox.jsx
@@ -2,7 +2,15 @@ import { Box, Typography, useTheme } from "@mui/material";
 import { tokens } from "../theme";
 import ProgressCircle from "./ProgressCircle";
 
-const StatBox = ({ title, lines, subtitle, icon, progress, increase }) => {
+const StatBox = ({
+  title,
+  lines,
+  subtitle,
+  icon,
+  progress,
+  increase,
+  increaseColor,
+}) => {
   const theme = useTheme();
   const colors = tokens(theme.palette.mode);
 
@@ -42,15 +50,15 @@ const StatBox = ({ title, lines, subtitle, icon, progress, increase }) => {
         <Typography variant="h5" sx={{ color: colors.greenAccent[500] }}>
           {subtitle}
         </Typography>
-        {increase && (
-          <Typography
-            variant="h5"
-            fontStyle="italic"
-            sx={{ color: colors.greenAccent[600] }}
-          >
-            {increase}
-          </Typography>
-        )}
+          {increase && (
+            <Typography
+              variant="h5"
+              fontStyle="italic"
+              sx={{ color: increaseColor || colors.greenAccent[600] }}
+            >
+              {increase}
+            </Typography>
+          )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- compute energy cost per profit metric and show as fourth dashboard widget
- display profit per square meter and show difference between top strategies
- allow StatBox to color increase text using best strategy color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68938c4076a083278fe0574d21951e8a