### PR TITLE
feat: assign strategy colors alphabetically

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -123,14 +123,21 @@ export const RadarProvider = ({ data = {}, batches = [], children }) => {
   }, [strategies]);
 
   const colorMap = useMemo(() => {
-    const sorted = [...strategies].sort(
-      (a, b) =>
-        (Number(b.profit_per_m2) || 0) - (Number(a.profit_per_m2) || 0)
+    const names = strategies.map((s) => s.name).filter(Boolean);
+    const optimized = names.find(
+      (n) => n.toLowerCase() === "optimized"
     );
+    const palette = COLOR_PALETTE.slice(1);
     const map = {};
-    sorted.forEach((s, idx) => {
-      map[s.name] = COLOR_PALETTE[idx % COLOR_PALETTE.length];
-    });
+    names
+      .filter((n) => n !== optimized)
+      .sort((a, b) => a.localeCompare(b))
+      .forEach((name, idx) => {
+        map[name] = palette[idx % palette.length];
+      });
+    if (optimized) {
+      map[optimized] = COLOR_PALETTE[0];
+    }
     return map;
   }, [strategies]);
 


### PR DESCRIPTION
## Summary
- keep `optimized` strategy gold
- map remaining strategies alphabetically to palette

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6893b59d174083279121caffa0e2e6a2