### PR TITLE
Refine ROI widget and enlarge radar plot labels

### DIFF
--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -22,7 +22,7 @@ function renderActiveDot(color, name) {
           y={Number(cy) - 8}
           textAnchor="middle"
           fill={color}
-          fontSize={12}
+          fontSize={14}
           fontWeight="bold"
         >
           {raw}
@@ -65,7 +65,7 @@ const renderAngleTick = (props) => {
       y={yNum + dy}
       textAnchor={isLeft ? "end" : "start"}
       fill="currentColor"
-      fontSize={12}
+      fontSize={14}
     >
       {payload.value}
     </text>

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -167,8 +167,8 @@ const DashboardContent = ({ energyData }) => {
             averages[key] = null;
           }
         });
-        averages.energy_cost_per_profit = totals.profit_total
-          ? roundToThree(totals.energy_cost_total / totals.profit_total)
+        averages.profit_per_energy_cost = totals.energy_cost_total
+          ? roundToThree(totals.profit_total / totals.energy_cost_total)
           : null;
         result[strategy] = averages;
       });
@@ -300,8 +300,8 @@ const DashboardContent = ({ energyData }) => {
           justifyContent="center"
         >
           <StatBox
-            lines={buildLines("energy_cost_per_profit")}
-            subtitle="Energy Cost per Profit (€/€)"
+            lines={buildLines("profit_per_energy_cost")}
+            subtitle="Return on Energy Cost (€/€)"
             icon={
               <SavingsIcon
                 sx={{ color: colors.greenAccent[600], fontSize: "26px" }}


### PR DESCRIPTION
## Summary
- compute profit return per energy cost instead of cost per profit
- show explicit units in ROI widget
- enlarge radar plot axis and dot label font sizes

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6893b74e0208832783f42e5aedba5a8f