### PR TITLE
Ensure consistent strategy colors across dashboard

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
-const COLOR_PALETTE = [
+export const COLOR_PALETTE = [
   "#FFD700",
   "#2ca02c",
   "#d62728",
@@ -12,6 +12,25 @@ const COLOR_PALETTE = [
   "#7f7f7f",
   "#17becf",
 ];
+
+export const generateColorMap = (names = []) => {
+  const filtered = names.filter(Boolean);
+  const optimized = filtered.find(
+    (n) => n.toLowerCase() === "optimized"
+  );
+  const palette = COLOR_PALETTE.slice(1);
+  const map = {};
+  filtered
+    .filter((n) => n !== optimized)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((name, idx) => {
+      map[name] = palette[idx % palette.length];
+    });
+  if (optimized) {
+    map[optimized] = COLOR_PALETTE[0];
+  }
+  return map;
+};
 
 const RadarContext = createContext();
 
@@ -122,24 +141,10 @@ export const RadarProvider = ({ data = {}, batches = [], children }) => {
     });
   }, [strategies]);
 
-  const colorMap = useMemo(() => {
-    const names = strategies.map((s) => s.name).filter(Boolean);
-    const optimized = names.find(
-      (n) => n.toLowerCase() === "optimized"
-    );
-    const palette = COLOR_PALETTE.slice(1);
-    const map = {};
-    names
-      .filter((n) => n !== optimized)
-      .sort((a, b) => a.localeCompare(b))
-      .forEach((name, idx) => {
-        map[name] = palette[idx % palette.length];
-      });
-    if (optimized) {
-      map[optimized] = COLOR_PALETTE[0];
-    }
-    return map;
-  }, [strategies]);
+  const colorMap = useMemo(
+    () => generateColorMap(baseData.strategies),
+    [baseData]
+  );
 
   const toggleCultivation = (name) => {
     setSelectedCultivations((prev) =>

--- a/src/radarplot/RadarControls.test.js
+++ b/src/radarplot/RadarControls.test.js
@@ -1,0 +1,16 @@
+import { generateColorMap, COLOR_PALETTE } from "./RadarControls";
+
+describe("generateColorMap", () => {
+  it("assigns gold to optimized and sorts others alphabetically", () => {
+    const map = generateColorMap(["B", "Optimized", "A"]);
+    expect(map.Optimized).toBe(COLOR_PALETTE[0]);
+    expect(map.A).toBe(COLOR_PALETTE[1]);
+    expect(map.B).toBe(COLOR_PALETTE[2]);
+  });
+
+  it("returns consistent colors regardless of input order", () => {
+    const first = generateColorMap(["Alpha", "Beta", "Gamma"]);
+    const second = generateColorMap(["Gamma", "Alpha", "Beta"]);
+    expect(first).toEqual(second);
+  });
+});


### PR DESCRIPTION
## Summary
- Stabilize strategy color mapping: gold for optimized, alphabetical order for others
- Provide `generateColorMap` helper and expose palette
- Add tests ensuring consistent color assignment

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68944c89577483279433f1565132aaf3