### PR TITLE
feat: add profit distribution chart

### DIFF
--- a/src/components/dashboard/ProfitDistribution.tsx
+++ b/src/components/dashboard/ProfitDistribution.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from "react";
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+  LabelList,
+  Cell,
+} from "recharts";
+
+interface WeightBin {
+  bin: string;
+  count: number;
+  category: string;
+  revenue: number;
+}
+
+interface WeightDistributionData {
+  cultivation_id: string;
+  name: string;
+  target_weight: number;
+  upper_cap: number;
+  lower_cap: number;
+  weight_bin_distribution: WeightBin[];
+}
+
+interface ProfitDistributionProps {
+  selectedCultivation?: string | null;
+  selectedStrategy?: string | null;
+  data: any[];
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  A: "#f44336", // red
+  B: "#ff9800", // orange
+  C: "#4caf50", // green
+  D: "#2196f3", // blue
+};
+
+const ProfitDistribution: React.FC<ProfitDistributionProps> = ({
+  selectedCultivation,
+  selectedStrategy,
+  data,
+}) => {
+  const [metric, setMetric] = useState<"count" | "revenue">("count");
+
+  if (!selectedCultivation || !selectedStrategy) {
+    return (
+      <div className="p-4 text-center text-sm">
+        👆 Select a single cultivation and strategy to view the profit distribution.
+      </div>
+    );
+  }
+
+  const selectedEntry = data.find(
+    (d) =>
+      d.cultivation_id === selectedCultivation &&
+      (d.strategy_name === selectedStrategy || d.strategy === selectedStrategy)
+  );
+
+  const dist: WeightDistributionData | undefined =
+    selectedEntry?.weight_distribution_data || selectedEntry;
+
+  if (!dist || !dist.weight_bin_distribution) {
+    return (
+      <div className="p-4 text-center text-sm">
+        No distribution data available.
+      </div>
+    );
+  }
+
+  const bins = dist.weight_bin_distribution;
+
+  return (
+    <div className="w-full h-full flex flex-col">
+      <div className="p-4 border-b border-gray-700 flex justify-between items-center">
+        <div>
+          <h2 className="text-lg font-semibold">
+            📊 Profit Distribution by Weight
+          </h2>
+          <div className="text-xs mt-1 text-gray-400">
+            Target: {dist.target_weight}g · Lower penalty: {dist.lower_cap}g · Bonus cap: {dist.upper_cap}g
+          </div>
+        </div>
+        <select
+          className="bg-transparent border border-gray-500 text-sm p-1 rounded"
+          value={metric}
+          onChange={(e) => setMetric(e.target.value as "count" | "revenue")}
+        >
+          <option value="count">Count</option>
+          <option value="revenue">Revenue</option>
+        </select>
+      </div>
+      <div className="flex-1 p-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <RechartsBarChart data={bins}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="bin" />
+            <YAxis />
+            <Tooltip
+              formatter={(value: any, name: any) => {
+                if (name === "revenue") return [`€${value}`, "Revenue"];
+                return [value, name];
+              }}
+            />
+            <Bar dataKey={metric} isAnimationActive>
+              <LabelList dataKey={metric} position="top" className="fill-current text-xs" />
+              {bins.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={CATEGORY_COLORS[entry.category] || "#8884d8"}
+                />
+              ))}
+            </Bar>
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default ProfitDistribution;

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -1,7 +1,6 @@
 import { Box, Button, IconButton, Typography, useTheme } from "@mui/material";
 import { useEffect, useState, useMemo } from "react";
 import { tokens } from "../../theme";
-import { mockTransactions } from "../../data/mockData";
 import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
 import EuroSymbolIcon from "@mui/icons-material/EuroSymbol";
 import LocalFloristIcon from "@mui/icons-material/LocalFlorist";
@@ -13,6 +12,7 @@ import BarChart from "../../components/BarChart";
 import StatBox from "../../components/StatBox";
 import RadarPlot from "../../radarplot/RadarPlot";
 import RadarControls, { RadarProvider, useRadar } from "../../radarplot/RadarControls";
+import ProfitDistribution from "../../components/dashboard/ProfitDistribution";
 
 // Fallback to the public admin gist when no environment variable is provided
 const DEFAULT_GIST_ID =
@@ -124,6 +124,21 @@ const DashboardContent = ({ energyData }) => {
     kpis = {},
     colorMap = {},
   } = radar || {};
+
+  const activeStrategies = Object.keys(visible || {}).filter((s) => visible[s]);
+  const singleStrategy =
+    activeStrategies.length === 1 ? activeStrategies[0] : null;
+  const singleCultivation =
+    selectedCultivations.length === 1 ? selectedCultivations[0] : null;
+
+  const weightData = useMemo(
+    () =>
+      Object.entries(kpis || {}).map(([key, value]) => {
+        const [cultivation_id, strategy_name] = key.split("|");
+        return { cultivation_id, strategy_name, ...value };
+      }),
+    [kpis]
+  );
 
   const roundToThree = (n) => Math.round((n + Number.EPSILON) * 1000) / 1000;
 
@@ -357,49 +372,11 @@ const DashboardContent = ({ energyData }) => {
           backgroundColor={colors.primary[400]}
           overflow="auto"
         >
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            borderBottom={`4px solid ${colors.primary[500]}`}
-            colors={colors.grey[100]}
-            p="15px"
-          >
-            <Typography color={colors.grey[100]} variant="h5" fontWeight="600">
-              Recent Transactions
-            </Typography>
-          </Box>
-          {mockTransactions.map((transaction, i) => (
-            <Box
-              key={`${transaction.txId}-${i}`}
-              display="flex"
-              justifyContent="space-between"
-              alignItems="center"
-              borderBottom={`4px solid ${colors.primary[500]}`}
-              p="15px"
-            >
-              <Box>
-                <Typography
-                  color={colors.greenAccent[500]}
-                  variant="h5"
-                  fontWeight="600"
-                >
-                  {transaction.txId}
-                </Typography>
-                <Typography color={colors.grey[100]}>
-                  {transaction.user}
-                </Typography>
-              </Box>
-              <Box color={colors.grey[100]}>{transaction.date}</Box>
-              <Box
-                backgroundColor={colors.greenAccent[500]}
-                p="5px 10px"
-                borderRadius="4px"
-              >
-                ${transaction.cost}
-              </Box>
-            </Box>
-          ))}
+          <ProfitDistribution
+            selectedCultivation={singleCultivation}
+            selectedStrategy={singleStrategy}
+            data={weightData}
+          />
         </Box>
 
         {/* ROW 3 */}


### PR DESCRIPTION
## Summary
- replace Recent Transactions widget with ProfitDistribution chart for single cultivation/strategy
- show weight-bin profit distribution with dynamic count/revenue toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689467ed7b5483278041c9a23024cccd