### PR TITLE
Add profit distribution chart to dashboard

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -11,25 +11,19 @@ import {
   Cell,
 } from "recharts";
 
-export interface ProfitDistributionProps {
-  selectedCultivation?: string | null;
-  selectedStrategy?: string | null;
-  data?: Record<string, any>;
-}
-
-const barColors: Record<string, string> = {
+const barColors = {
   A: "#ff0000",
   B: "#ffa500",
   C: "#008000",
   D: "#0000ff",
 };
 
-const ProfitDistribution: React.FC<ProfitDistributionProps> = ({
+const ProfitDistribution = ({
   selectedCultivation,
   selectedStrategy,
   data = {},
 }) => {
-  const [mode, setMode] = useState<"count" | "revenue">("count");
+  const [mode, setMode] = useState("count");
 
   if (!selectedCultivation || !selectedStrategy) {
     return (
@@ -60,7 +54,7 @@ const ProfitDistribution: React.FC<ProfitDistributionProps> = ({
         <select
           className="bg-gray-700 text-white text-sm p-1 rounded"
           value={mode}
-          onChange={(e) => setMode(e.target.value as "count" | "revenue")}
+          onChange={(e) => setMode(e.target.value)}
         >
           <option value="count">Count</option>
           <option value="revenue">Revenue</option>
@@ -80,7 +74,7 @@ const ProfitDistribution: React.FC<ProfitDistributionProps> = ({
             <Tooltip
               content={({ active, payload, label }) => {
                 if (active && payload && payload.length) {
-                  const item: any = payload[0].payload;
+                  const item = payload[0].payload;
                   return (
                     <div className="bg-gray-800 p-2 text-sm">
                       <p className="font-semibold">{label}</p>
@@ -95,7 +89,7 @@ const ProfitDistribution: React.FC<ProfitDistributionProps> = ({
             />
             <Bar dataKey={mode} isAnimationActive animationDuration={800}>
               <LabelList dataKey={mode} position="top" className="text-xs" />
-              {distribution.map((d: any, idx: number) => (
+              {distribution.map((d, idx) => (
                 <Cell key={`cell-${idx}`} fill={barColors[d.category] || "#8884d8"} />
               ))}
             </Bar>

--- a/src/components/dashboard/ProfitDistribution.tsx
+++ b/src/components/dashboard/ProfitDistribution.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from "react";
+import {
+  BarChart as ReBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  LabelList,
+  Cell,
+} from "recharts";
+
+export interface ProfitDistributionProps {
+  selectedCultivation?: string | null;
+  selectedStrategy?: string | null;
+  data?: Record<string, any>;
+}
+
+const barColors: Record<string, string> = {
+  A: "#ff0000",
+  B: "#ffa500",
+  C: "#008000",
+  D: "#0000ff",
+};
+
+const ProfitDistribution: React.FC<ProfitDistributionProps> = ({
+  selectedCultivation,
+  selectedStrategy,
+  data = {},
+}) => {
+  const [mode, setMode] = useState<"count" | "revenue">("count");
+
+  if (!selectedCultivation || !selectedStrategy) {
+    return (
+      <div className="p-4 text-center">
+        <p className="text-sm">
+          👆 Select a single cultivation and strategy to view the profit distribution.
+        </p>
+      </div>
+    );
+  }
+
+  const key = `${selectedCultivation}|${selectedStrategy}`;
+  const entry = data[key] || {};
+  const distribution = entry.weight_distribution_data || [];
+
+  if (!Array.isArray(distribution) || distribution.length === 0) {
+    return (
+      <div className="p-4 text-center">
+        <p className="text-sm">No distribution data available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between border-b border-gray-600 p-4">
+        <h2 className="text-lg font-semibold">📊 Profit Distribution by Weight</h2>
+        <select
+          className="bg-gray-700 text-white text-sm p-1 rounded"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as "count" | "revenue")}
+        >
+          <option value="count">Count</option>
+          <option value="revenue">Revenue</option>
+        </select>
+      </div>
+      <div className="p-4 text-sm flex flex-wrap gap-4">
+        <span>Target: {entry.target_weight}</span>
+        <span>Lower penalty threshold: {entry.lower_cap}</span>
+        <span>Bonus cap: {entry.upper_cap}</span>
+      </div>
+      <div className="flex-1 p-4">
+        <ResponsiveContainer width="100%" height="100%">
+          <ReBarChart data={distribution} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="bin" />
+            <YAxis />
+            <Tooltip
+              content={({ active, payload, label }) => {
+                if (active && payload && payload.length) {
+                  const item: any = payload[0].payload;
+                  return (
+                    <div className="bg-gray-800 p-2 text-sm">
+                      <p className="font-semibold">{label}</p>
+                      <p>Category: {item.category}</p>
+                      <p>Revenue: {item.revenue}</p>
+                      <p>{mode === "count" ? `Count: ${item.count}` : `Revenue: ${item.revenue}`}</p>
+                    </div>
+                  );
+                }
+                return null;
+              }}
+            />
+            <Bar dataKey={mode} isAnimationActive animationDuration={800}>
+              <LabelList dataKey={mode} position="top" className="text-xs" />
+              {distribution.map((d: any, idx: number) => (
+                <Cell key={`cell-${idx}`} fill={barColors[d.category] || "#8884d8"} />
+              ))}
+            </Bar>
+          </ReBarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default ProfitDistribution;
+

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -1,7 +1,6 @@
 import { Box, Button, IconButton, Typography, useTheme } from "@mui/material";
 import { useEffect, useState, useMemo } from "react";
 import { tokens } from "../../theme";
-import { mockTransactions } from "../../data/mockData";
 import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined";
 import EuroSymbolIcon from "@mui/icons-material/EuroSymbol";
 import LocalFloristIcon from "@mui/icons-material/LocalFlorist";
@@ -13,6 +12,7 @@ import BarChart from "../../components/BarChart";
 import StatBox from "../../components/StatBox";
 import RadarPlot from "../../radarplot/RadarPlot";
 import RadarControls, { RadarProvider, useRadar } from "../../radarplot/RadarControls";
+import ProfitDistribution from "../../components/dashboard/ProfitDistribution";
 
 // Fallback to the public admin gist when no environment variable is provided
 const DEFAULT_GIST_ID =
@@ -124,6 +124,12 @@ const DashboardContent = ({ energyData }) => {
     kpis = {},
     colorMap = {},
   } = radar || {};
+
+  const activeStrategies = Object.keys(visible || {}).filter((s) => visible[s]);
+  const selectedCultivation =
+    selectedCultivations.length === 1 ? selectedCultivations[0] : null;
+  const selectedStrategy =
+    activeStrategies.length === 1 ? activeStrategies[0] : null;
 
   const roundToThree = (n) => Math.round((n + Number.EPSILON) * 1000) / 1000;
 
@@ -356,50 +362,14 @@ const DashboardContent = ({ energyData }) => {
           gridRow="span 2"
           backgroundColor={colors.primary[400]}
           overflow="auto"
+          display="flex"
+          flexDirection="column"
         >
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            borderBottom={`4px solid ${colors.primary[500]}`}
-            colors={colors.grey[100]}
-            p="15px"
-          >
-            <Typography color={colors.grey[100]} variant="h5" fontWeight="600">
-              Recent Transactions
-            </Typography>
-          </Box>
-          {mockTransactions.map((transaction, i) => (
-            <Box
-              key={`${transaction.txId}-${i}`}
-              display="flex"
-              justifyContent="space-between"
-              alignItems="center"
-              borderBottom={`4px solid ${colors.primary[500]}`}
-              p="15px"
-            >
-              <Box>
-                <Typography
-                  color={colors.greenAccent[500]}
-                  variant="h5"
-                  fontWeight="600"
-                >
-                  {transaction.txId}
-                </Typography>
-                <Typography color={colors.grey[100]}>
-                  {transaction.user}
-                </Typography>
-              </Box>
-              <Box color={colors.grey[100]}>{transaction.date}</Box>
-              <Box
-                backgroundColor={colors.greenAccent[500]}
-                p="5px 10px"
-                borderRadius="4px"
-              >
-                ${transaction.cost}
-              </Box>
-            </Box>
-          ))}
+          <ProfitDistribution
+            selectedCultivation={selectedCultivation}
+            selectedStrategy={selectedStrategy}
+            data={kpis}
+          />
         </Box>
 
         {/* ROW 3 */}


### PR DESCRIPTION
## Summary
- show harvest profit distribution by weight when exactly one cultivation and strategy are selected
- replace the Recent Transactions section with the new chart

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68947536e89c8327a437c01ad4cb5965