### PR TITLE
Handle stringified distribution data

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -37,7 +37,15 @@ const ProfitDistribution = ({
 
   const key = `${selectedCultivation}|${selectedStrategy}`;
   const entry = data[key] || {};
-  const distribution = entry.weight_distribution_data || [];
+  let distribution = entry.weight_distribution_data || entry.weight_distribution || [];
+
+  if (typeof distribution === "string") {
+    try {
+      distribution = JSON.parse(distribution);
+    } catch (err) {
+      distribution = [];
+    }
+  }
 
   if (!Array.isArray(distribution) || distribution.length === 0) {
     return (


### PR DESCRIPTION
## Summary
- Parse weight distribution when received as a JSON string
- Support both `weight_distribution_data` and `weight_distribution` fields

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6894885dce488327a10698467bef60c1