### PR TITLE
Highlight optimized strategy and enlarge radar labels

### DIFF
--- a/src/radarplot/RadarControls.jsx
+++ b/src/radarplot/RadarControls.jsx
@@ -15,8 +15,8 @@ export const COLOR_PALETTE = [
 
 export const generateColorMap = (names = []) => {
   const filtered = names.filter(Boolean);
-  const optimized = filtered.find(
-    (n) => n.toLowerCase() === "optimized"
+  const optimized = filtered.find((n) =>
+    n.toLowerCase().includes("optimized")
   );
   const palette = COLOR_PALETTE.slice(1);
   const map = {};

--- a/src/radarplot/RadarControls.test.js
+++ b/src/radarplot/RadarControls.test.js
@@ -8,6 +8,13 @@ describe("generateColorMap", () => {
     expect(map.B).toBe(COLOR_PALETTE[2]);
   });
 
+  it("handles names containing 'optimized'", () => {
+    const map = generateColorMap(["B", "Optimized Plan", "A"]);
+    expect(map["Optimized Plan"]).toBe(COLOR_PALETTE[0]);
+    expect(map.A).toBe(COLOR_PALETTE[1]);
+    expect(map.B).toBe(COLOR_PALETTE[2]);
+  });
+
   it("returns consistent colors regardless of input order", () => {
     const first = generateColorMap(["Alpha", "Beta", "Gamma"]);
     const second = generateColorMap(["Gamma", "Alpha", "Beta"]);

--- a/src/radarplot/RadarPlot.jsx
+++ b/src/radarplot/RadarPlot.jsx
@@ -22,7 +22,7 @@ function renderActiveDot(color, name) {
           y={Number(cy) - 8}
           textAnchor="middle"
           fill={color}
-          fontSize={14}
+          fontSize={18}
           fontWeight="bold"
         >
           {raw}


### PR DESCRIPTION
## Summary
- ensure any strategy name containing "optimized" is always colored gold
- enlarge radar chart value labels for better hover readability
- cover optimized name matching with additional tests

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68950edba73883278391d9553ca01489