### PR TITLE
Expand profit distribution plot to span two grid rows

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -69,8 +69,8 @@ const ProfitDistribution = ({ selectedCultivation, selectedStrategy, data = {} }
         <span>⏫ Bonus cap: {entry.upper_cap ?? "?"}g</span>
       </div>
 
-      <div className="flex-1 p-4">
-        <ResponsiveContainer width="100%" height={300}>
+      <div className="flex-1 p-4 h-full">
+        <ResponsiveContainer width="100%" height="100%">
           <BarChart data={distribution} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="bin" label={{ value: "Weight (g)", position: "insideBottom", dy: 10 }} />

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -364,6 +364,7 @@ const DashboardContent = ({ energyData }) => {
           overflow="auto"
           display="flex"
           flexDirection="column"
+          height="100%"
         >
           <ProfitDistribution
             selectedCultivation={selectedCultivation}


### PR DESCRIPTION
## Summary
- Ensure the ProfitDistribution chart stretches to fill its container
- Allow the dashboard grid cell for ProfitDistribution to span two rows fully

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689b711fe0888327a9920ec9f42ab3ad