### PR TITLE
Expand profit distribution plot to span two grid rows

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -50,7 +50,7 @@ const ProfitDistribution = ({ selectedCultivation, selectedStrategy, data = {} }
     .sort((a, b) => a.bin - b.bin);
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full w-full">
       <div className="flex items-center justify-between border-b border-gray-600 p-4">
         <h2 className="text-lg font-semibold">📊 Profit Distribution by Weight</h2>
         <select
@@ -69,8 +69,8 @@ const ProfitDistribution = ({ selectedCultivation, selectedStrategy, data = {} }
         <span>⏫ Bonus cap: {entry.upper_cap ?? "?"}g</span>
       </div>
 
-      <div className="flex-1 p-4">
-        <ResponsiveContainer width="100%" height={300}>
+      <div className="flex-grow p-4 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
           <BarChart data={distribution} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="bin" label={{ value: "Weight (g)", position: "insideBottom", dy: 10 }} />

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -359,11 +359,12 @@ const DashboardContent = ({ energyData }) => {
         </Box>
         <Box
           gridColumn="9 / span 4"
-          gridRow="span 2"
+          gridRow="2 / span 2"
           backgroundColor={colors.primary[400]}
           overflow="auto"
           display="flex"
           flexDirection="column"
+          height="100%"
         >
           <ProfitDistribution
             selectedCultivation={selectedCultivation}


### PR DESCRIPTION
## Summary
- Let the ProfitDistribution chart grow to fill its container
- Pin the ProfitDistribution widget to row 2 of the dashboard and span two rows

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689b711fe0888327a9920ec9f42ab3ad