### PR TITLE
Support multiple strategy profit distribution charts

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -12,28 +12,27 @@ import {
 
 const ProfitDistribution = ({
   selectedCultivation,
-  selectedStrategy,
+  selectedStrategies = [],
   data = {},
   colorMap = {},
 }) => {
   const [mode, setMode] = useState("count");
 
-  // Guard: only show chart if 1 cultivation and 1 strategy are selected
-  if (!selectedCultivation || !selectedStrategy) {
+  // Require a single cultivation and at least one strategy
+  if (!selectedCultivation || selectedStrategies.length === 0) {
     return (
       <div className="p-4 text-center">
         <p className="text-sm">
-          👆 Select a single cultivation and strategy to view the profit distribution.
+          Select a cultivation and at least one strategy to view the profit distribution.
         </p>
       </div>
     );
   }
 
-  const key = `${selectedCultivation}|${selectedStrategy}`;
-  const entry = data[key] || {};
-  const distObj = entry.distribution;
+  const formatWeight = (val) =>
+    val !== null && val !== undefined ? `${val}g` : "?g";
 
-  const resolveWeight = (...keys) => {
+  const resolveWeight = (entry, ...keys) => {
     for (const k of keys) {
       if (
         entry.targets &&
@@ -46,94 +45,136 @@ const ProfitDistribution = ({
     return null;
   };
 
-  const target = resolveWeight(
-    "target_weight",
-    "target",
-    "target_weight_g",
-    "targetWeight"
-  );
-  const lowerCap = resolveWeight(
-    "lower_cap",
-    "lower",
-    "lower_cap_weight",
-    "lowerCap"
-  );
-  const bonusCap = resolveWeight(
-    "upper_cap",
-    "bonus_cap",
-    "upper",
-    "upper_cap_weight",
-    "upperCap"
-  );
-
-  const formatWeight = (val) =>
-    val !== null && val !== undefined ? `${val}g` : "?g";
-
-  const barColor = colorMap[selectedStrategy] || "#8884d8";
-
-  if (!distObj || typeof distObj !== "object" || Object.keys(distObj).length === 0) {
-    return (
-      <div className="p-4 text-center">
-        <p className="text-sm">No distribution data available.</p>
-      </div>
-    );
-  }
-
-  // Convert { "65": 100, "70": 200 } → [{ bin: 65, count: 100 }, ...]
-  const distribution = Object.entries(distObj)
-    .map(([bin, count]) => ({ bin: parseInt(bin, 10), count: Number(count) }))
-    .sort((a, b) => a.bin - b.bin);
-
   return (
     <div className="flex flex-col h-full w-full">
       <div className="flex items-center justify-between border-b border-gray-600 p-4">
-        <h2 className="text-lg font-semibold">📊 Profit Distribution by Weight</h2>
+        <h2 className="text-lg font-semibold">Profit Distribution by Weight</h2>
         <select
           className="bg-gray-700 text-white text-sm p-1 rounded"
           value={mode}
           onChange={(e) => setMode(e.target.value)}
         >
           <option value="count">Count</option>
-          <option value="revenue" disabled>Revenue (todo)</option>
+          <option value="revenue" disabled>
+            Revenue (todo)
+          </option>
         </select>
       </div>
+      <div className="flex flex-row flex-wrap h-full">
+        {selectedStrategies.map((strategy) => {
+          const key = `${selectedCultivation}|${strategy}`;
+          const entry = data[key] || {};
+          const distObj = entry.distribution;
 
-      <div className="p-4 text-sm flex flex-wrap gap-4">
-        <span>🎯 Target: {formatWeight(target)}</span>
-        <span>⏬ Lower cap: {formatWeight(lowerCap)}</span>
-        <span>⏫ Bonus cap: {formatWeight(bonusCap)}</span>
-      </div>
+          if (
+            !distObj ||
+            typeof distObj !== "object" ||
+            Object.keys(distObj).length === 0
+          ) {
+            return (
+              <div
+                key={strategy}
+                className="flex flex-col flex-1 min-w-[300px] p-4"
+              >
+                <h3 className="text-center font-semibold mb-2">{strategy}</h3>
+                <p className="text-sm text-center">No distribution data available.</p>
+              </div>
+            );
+          }
 
-      <div className="flex-grow p-4 min-h-0">
-        <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={distribution} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="bin" label={{ value: "Weight (g)", position: "insideBottom", dy: 10 }} />
-            <YAxis label={{ value: "Count", angle: -90, dx: -10 }} />
-            <Tooltip
-              content={({ active, payload, label }) => {
-                if (active && payload && payload.length) {
-                  const item = payload[0].payload;
-                  return (
-                    <div className="bg-gray-800 p-2 text-sm text-white rounded">
-                      <p className="font-semibold">{label}g</p>
-                      <p>{mode === "count" ? `Count: ${item.count}` : `Revenue: ${item.revenue}`}</p>
-                    </div>
-                  );
-                }
-                return null;
-              }}
-            />
-            <Bar
-              dataKey={mode}
-              isAnimationActive
-              animationDuration={800}
-              fill={barColor}
+          const target = resolveWeight(
+            entry,
+            "target_weight",
+            "target",
+            "target_weight_g",
+            "targetWeight"
+          );
+          const lowerCap = resolveWeight(
+            entry,
+            "lower_cap",
+            "lower",
+            "lower_cap_weight",
+            "lowerCap"
+          );
+          const bonusCap = resolveWeight(
+            entry,
+            "upper_cap",
+            "bonus_cap",
+            "upper",
+            "upper_cap_weight",
+            "upperCap"
+          );
+
+          const distribution = Object.entries(distObj)
+            .map(([bin, count]) => ({
+              bin: parseInt(bin, 10),
+              count: Number(count),
+            }))
+            .sort((a, b) => a.bin - b.bin);
+
+          const barColor = colorMap[strategy] || "#8884d8";
+
+          return (
+            <div
+              key={strategy}
+              className="flex flex-col flex-1 min-w-[300px] border-r last:border-r-0 border-gray-600"
             >
-              <LabelList dataKey={mode} position="top" className="text-xs" />
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
+              <h3 className="text-center font-semibold mt-2">{strategy}</h3>
+              <div className="p-4 text-sm flex flex-wrap gap-4">
+                <span>🎯 Target: {formatWeight(target)}</span>
+                <span>⏬ Lower cap: {formatWeight(lowerCap)}</span>
+                <span>⏫ Bonus cap: {formatWeight(bonusCap)}</span>
+              </div>
+              <div className="flex-grow p-4 min-h-0">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart
+                    data={distribution}
+                    margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="bin"
+                      label={{ value: "Weight (g)", position: "insideBottom", dy: 10 }}
+                    />
+                    <YAxis
+                      label={{
+                        value: mode === "count" ? "Count" : "Revenue",
+                        angle: -90,
+                        dx: -10,
+                      }}
+                    />
+                    <Tooltip
+                      content={({ active, payload, label }) => {
+                        if (active && payload && payload.length) {
+                          const item = payload[0].payload;
+                          return (
+                            <div className="bg-gray-800 p-2 text-sm text-white rounded">
+                              <p className="font-semibold">{label}g</p>
+                              <p>
+                                {mode === "count"
+                                  ? `Count: ${item.count}`
+                                  : `Revenue: ${item.revenue}`}
+                              </p>
+                            </div>
+                          );
+                        }
+                        return null;
+                      }}
+                    />
+                    <Bar
+                      dataKey={mode}
+                      isAnimationActive
+                      animationDuration={800}
+                      fill={barColor}
+                    >
+                      <LabelList dataKey={mode} position="top" className="text-xs" />
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/scenes/dashboard/index.jsx
+++ b/src/scenes/dashboard/index.jsx
@@ -165,8 +165,7 @@ const DashboardContent = ({ energyData }) => {
   const activeStrategies = Object.keys(visible || {}).filter((s) => visible[s]);
   const selectedCultivation =
     selectedCultivations.length === 1 ? selectedCultivations[0] : null;
-  const selectedStrategy =
-    activeStrategies.length === 1 ? activeStrategies[0] : null;
+  const selectedStrategies = activeStrategies;
 
   const roundToThree = (n) => Math.round((n + Number.EPSILON) * 1000) / 1000;
 
@@ -405,7 +404,7 @@ const DashboardContent = ({ energyData }) => {
         >
           <ProfitDistribution
             selectedCultivation={selectedCultivation}
-            selectedStrategy={selectedStrategy}
+            selectedStrategies={selectedStrategies}
             data={kpis}
             colorMap={colorMap}
           />


### PR DESCRIPTION
## Summary
- allow selecting and visualizing multiple strategies in Profit Distribution widget
- remove emoji from Profit Distribution heading

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689c5f020cfc83278dde5b17c4e1154d