### PR TITLE
Adjust ProfitDistribution chart styling

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -147,28 +147,46 @@ const ProfitDistribution = ({
             <span className="font-semibold">{p.strategy}</span>
           </div>
         ))}
-        <div className="flex items-center gap-2">
-          <span
+        <div className="flex items-center gap-4">
+          <div
+            className="flex items-center gap-1"
             title={prepared
               .map((p) => `${p.strategy}: ${formatWeight(p.target)}`)
               .join("\n")}
           >
-            🎯
-          </span>
-          <span
+            <span>🎯</span>
+            <span>
+              {prepared
+                .map((p) => `${p.strategy}: ${formatWeight(p.target)}`)
+                .join(", ")}
+            </span>
+          </div>
+          <div
+            className="flex items-center gap-1"
             title={prepared
               .map((p) => `${p.strategy}: ${formatWeight(p.lowerCap)}`)
               .join("\n")}
           >
-            ⏬
-          </span>
-          <span
+            <span>⏬</span>
+            <span>
+              {prepared
+                .map((p) => `${p.strategy}: ${formatWeight(p.lowerCap)}`)
+                .join(", ")}
+            </span>
+          </div>
+          <div
+            className="flex items-center gap-1"
             title={prepared
               .map((p) => `${p.strategy}: ${formatWeight(p.bonusCap)}`)
               .join("\n")}
           >
-            ⏫
-          </span>
+            <span>⏫</span>
+            <span>
+              {prepared
+                .map((p) => `${p.strategy}: ${formatWeight(p.bonusCap)}`)
+                .join(", ")}
+            </span>
+          </div>
         </div>
       </div>
       <div className="flex-grow p-4 min-h-0">
@@ -176,8 +194,8 @@ const ProfitDistribution = ({
           <BarChart
             data={chartData}
             margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
-            barGap={0}
-            barCategoryGap="0%"
+            barGap={4}
+            barCategoryGap="20%"
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
@@ -193,7 +211,6 @@ const ProfitDistribution = ({
               tickFormatter={(v) => (v >= 1000 ? `${v / 1000}k` : v)}
             />
             <Tooltip />
-            <Legend />
             {prepared.map((p) => (
               <Bar
                 key={p.strategy}


### PR DESCRIPTION
## Summary
- Show per-strategy weight values next to target, lower cap, and bonus cap emojis in ProfitDistribution
- Narrow bar spacing and remove duplicate legend for cleaner weight distribution visualization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c6885aa108327bf9bd71c2e0cf0a6