### PR TITLE
Simplify profit distribution legend and remove bar spacing

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -148,44 +148,17 @@ const ProfitDistribution = ({
           </div>
         ))}
         <div className="flex items-center gap-4">
-          <div
-            className="flex items-center gap-1"
-            title={prepared
-              .map((p) => `${p.strategy}: ${formatWeight(p.target)}`)
-              .join("\n")}
-          >
+          <div className="flex items-center gap-1">
             <span>🎯</span>
-            <span>
-              {prepared
-                .map((p) => `${p.strategy}: ${formatWeight(p.target)}`)
-                .join(", ")}
-            </span>
+            <span>{formatWeight(prepared[0].target)}</span>
           </div>
-          <div
-            className="flex items-center gap-1"
-            title={prepared
-              .map((p) => `${p.strategy}: ${formatWeight(p.lowerCap)}`)
-              .join("\n")}
-          >
+          <div className="flex items-center gap-1">
             <span>⏬</span>
-            <span>
-              {prepared
-                .map((p) => `${p.strategy}: ${formatWeight(p.lowerCap)}`)
-                .join(", ")}
-            </span>
+            <span>{formatWeight(prepared[0].lowerCap)}</span>
           </div>
-          <div
-            className="flex items-center gap-1"
-            title={prepared
-              .map((p) => `${p.strategy}: ${formatWeight(p.bonusCap)}`)
-              .join("\n")}
-          >
+          <div className="flex items-center gap-1">
             <span>⏫</span>
-            <span>
-              {prepared
-                .map((p) => `${p.strategy}: ${formatWeight(p.bonusCap)}`)
-                .join(", ")}
-            </span>
+            <span>{formatWeight(prepared[0].bonusCap)}</span>
           </div>
         </div>
       </div>
@@ -194,8 +167,8 @@ const ProfitDistribution = ({
           <BarChart
             data={chartData}
             margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
-            barGap={4}
-            barCategoryGap="20%"
+            barGap={0}
+            barCategoryGap="0%"
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis


### PR DESCRIPTION
## Summary
- Show target, lower cap, and bonus cap values once with their respective icons
- Remove space between histogram bars for tighter visualization

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689c6dfe212083278e3d12bb95bc5c4a