### PR TITLE
Remove horizontal scroll in weight distribution

### DIFF
--- a/src/components/dashboard/ProfitDistribution.jsx
+++ b/src/components/dashboard/ProfitDistribution.jsx
@@ -129,7 +129,6 @@ const ProfitDistribution = ({
     });
     return item;
   });
-  const chartWidth = Math.max(allBins.length * 50, 300);
   const ChartContent = ({ actionButton }) => (
     <div className="flex flex-col h-full w-full">
       <div className="flex items-center justify-between border-b border-gray-600 p-4">
@@ -173,8 +172,8 @@ const ProfitDistribution = ({
           </div>
         </div>
       </div>
-      <div className="flex-grow p-4 min-h-0 overflow-x-auto">
-        <div style={{ minWidth: chartWidth, height: "100%" }}>
+      <div className="flex-grow p-4 min-h-0">
+        <div style={{ width: "100%", height: "100%" }}>
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={chartData}


### PR DESCRIPTION
## Summary
- Display entire weight distribution without horizontal scrolling by letting chart expand to the container width

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689c96d02dc88327a2ab89bafc1b6061